### PR TITLE
adds a label argument to useLogChanges

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,12 +11,19 @@ function usePrevious<T>(value: T) {
   return ref.current;
 }
 
+type Logger<T> = (item: Change<T> | string) => void;
+
 export function useLogChanges<T>(
   value: T,
-  logger: (change: Change<T>) => void = console.log
+  label?: string,
+  logger: Logger<T> = console.log
 ) {
   const previousValue = usePrevious<T>(value);
   const changes = getChanges<T>(previousValue, value);
+
+  if (label && changes.length) {
+    logger(label);
+  }
 
   changes.forEach(change => {
     logger(change);
@@ -25,32 +32,36 @@ export function useLogChanges<T>(
 
 export function useEffectDebugger(
   effect: React.EffectCallback,
-  dependencies: React.DependencyList | undefined
+  dependencies: React.DependencyList | undefined,
+  label?: string
 ) {
-  useLogChanges(dependencies);
+  useLogChanges(dependencies, label);
   React.useEffect(effect, dependencies);
 }
 
 export function useLayoutEffectDebugger(
   effect: React.EffectCallback,
-  dependencies: React.DependencyList | undefined
+  dependencies: React.DependencyList | undefined,
+  label?: string
 ) {
-  useLogChanges(dependencies);
+  useLogChanges(dependencies, label);
   React.useLayoutEffect(effect, dependencies);
 }
 
 export function useCallbackDebugger(
   callback: any,
-  dependencies: React.DependencyList
+  dependencies: React.DependencyList,
+  label?: string
 ) {
-  useLogChanges(dependencies);
+  useLogChanges(dependencies, label);
   return React.useCallback(callback, dependencies);
 }
 
 export function useMemoDebugger(
   memoizer: () => unknown,
-  dependencies: React.DependencyList | undefined
+  dependencies: React.DependencyList | undefined,
+  label?: string
 ) {
-  useLogChanges(dependencies);
+  useLogChanges(dependencies, label);
   return React.useMemo(memoizer, dependencies);
 }

--- a/test/index.test.tsx
+++ b/test/index.test.tsx
@@ -1,37 +1,88 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { useLogChanges } from '../src';
 
-type Logger = (x: any) => void;
-type Logs = any[];
-type LoggerTuple = [Logger, Logs];
-
 /**
  * This creates a `logger` function with `logs` stored in closure.
  * This allows us to test `useLogChanges` with a logger than doesn't
- * output to the console, but rather pushes the results into the `logs`
+ * output to the console, but rather pushes the results into the `logs` array
  * so we can verify that they are what we expect them to be.
  */
-function createLogger(): LoggerTuple {
-  const logs = [] as any[];
-  const logger = (x: any) => {
-    logs.push(x);
+function createLogger(): {
+  clearLogs: () => void;
+  getLogs: () => any[];
+  logger: (x: any) => void;
+} {
+  let logs = [] as any[];
+
+  const logger = (...x: any[]) => {
+    logs.push(...x);
   };
 
-  return [logger, logs];
+  return {
+    clearLogs: () => {
+      logs = [];
+    },
+    getLogs: () => {
+      return logs;
+    },
+    logger,
+  };
 }
 
-test('useLogChanges', () => {
-  const [logger, logs] = createLogger();
-  let initialValue = 0;
-  const { rerender } = renderHook(() => useLogChanges(initialValue, logger));
+describe('useLogChanges', () => {
+  const { clearLogs, getLogs, logger } = createLogger();
 
-  expect(logs).toEqual([{ previousValue: undefined, currentValue: 0 }]);
+  beforeEach(() => {
+    clearLogs();
+  });
 
-  initialValue = 1;
-  rerender();
+  it('should log out any changes that occur between renders', () => {
+    let initialValue = 0;
 
-  expect(logs).toEqual([
-    { previousValue: undefined, currentValue: 0 },
-    { previousValue: 0, currentValue: 1 },
-  ]);
+    const { rerender } = renderHook(() =>
+      useLogChanges(initialValue, undefined, logger)
+    );
+
+    expect(getLogs()).toEqual([{ previousValue: undefined, currentValue: 0 }]);
+
+    // A rerender with no changes
+    clearLogs();
+    rerender();
+
+    expect(getLogs()).toEqual([]);
+
+    // A rerender with changes
+    clearLogs();
+    initialValue = 1;
+    rerender();
+
+    expect(getLogs()).toEqual([{ previousValue: 0, currentValue: 1 }]);
+  });
+
+  it('should log out the provided label as well as any changes', () => {
+    let initialValue = 0;
+    const label = 'TEST LABEL';
+
+    const { rerender } = renderHook(() =>
+      useLogChanges(initialValue, label, logger)
+    );
+
+    expect(getLogs()).toEqual([
+      label,
+      { previousValue: undefined, currentValue: 0 },
+    ]);
+
+    // A rerender with no changes
+    clearLogs();
+    rerender();
+
+    expect(getLogs()).toEqual([]);
+
+    // A rerender with changes
+    clearLogs();
+    initialValue = 1;
+    rerender();
+
+    expect(getLogs()).toEqual([label, { previousValue: 0, currentValue: 1 }]);
+  });
 });


### PR DESCRIPTION
This optional label argument is then propagated through the debugger hooks as an optional third argument.

I'm not convinced I love this API. While I do agree that a label of sorts could be useful, I'm wondering it might not be simpler (and a better API) to just let the user write a console.log _before_ the debugger hook, like so:

```javascript
console.log('useEffect in MyComponent')
useEffectDebugger(() => {
  // do something
}, [dep1, dep2])
```

I will have to ponder this.